### PR TITLE
Co-pub report updates

### DIFF
--- a/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
+++ b/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
@@ -347,6 +347,7 @@ public class DataService {
         String rq = "SELECT \n" +
                 "      ?name\n" +
                 "      ?overview\n" +
+                "      ?country\n" +
                 "      ?coPubTotal\n" +
                 "      ?categories\n" +
                 "      ?orgTotal\n" +
@@ -358,6 +359,9 @@ public class DataService {
                 "WHERE {\n" +
                 "  ?org rdfs:label ?name .\n" +
                 "  OPTIONAL {  ?org vivo:overview ?overview }\n" +
+                "  OPTIONAL { ?org obo:RO_0001025 ?countryUri .\n" +
+                "            ?countryUri rdfs:label ?country " +
+                "  }\n" +
                 "{\n" +
                 "    SELECT (COUNT(DISTINCT ?pub) as ?coPubTotal) " +
                 "   WHERE {\n" +

--- a/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
+++ b/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
@@ -462,7 +462,7 @@ public class DataService {
     private ArrayList getTopCategories(final String orgUri, Integer startYear, 
             Integer endYear) {
         log.debug("Running top category query");
-        String rq = "select ?cat ?name ?number\n" +
+        String rq = "select ?cat ?name ?number ?year\n" +
                 "where {\n" +
                 "  ?count a wos:InCitesTopCategory ;\n" +
                 "         wos:number ?number ;\n" +

--- a/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
+++ b/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
@@ -466,6 +466,7 @@ public class DataService {
                 "where {\n" +
                 "  ?count a wos:InCitesTopCategory ;\n" +
                 "         wos:number ?number ;\n" +
+                "         wos:year ?year ;\n" +
                 "         vivo:relates ?org ;\n" +
                 "         vivo:relates ?cat .\n" +
                 "  ?cat a wos:Category ;\n" +

--- a/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
+++ b/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
@@ -462,10 +462,10 @@ public class DataService {
     private ArrayList getTopCategories(final String orgUri, Integer startYear, 
             Integer endYear) {
         log.debug("Running top category query");
-        String rq = "select ?cat ?name ?number ?year\n" +
+        String rq = "select ?name (sum(?yrNumber) as ?number)\n" +
                 "where {\n" +
                 "  ?count a wos:InCitesTopCategory ;\n" +
-                "         wos:number ?number ;\n" +
+                "         wos:number ?yrNumber ;\n" +
                 "         wos:year ?year ;\n" +
                 "         vivo:relates ?org ;\n" +
                 "         vivo:relates ?cat .\n" +
@@ -473,6 +473,7 @@ public class DataService {
                 "       rdfs:label ?name .\n" +
                 getYearFilter(startYear, endYear) +
                 "}\n" +
+                "GROUP BY ?name \n" +
                 "ORDER BY DESC(?number)";
         ParameterizedSparqlString q2 = this.storeUtils.getQuery(rq);
         q2.setCommandText(rq);

--- a/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
+++ b/custom-vivo/webapp/src/main/java/dk/dtu/adm/rap/controller/DataService.java
@@ -466,6 +466,7 @@ public class DataService {
                 "         vivo:relates ?cat .\n" +
                 "  ?cat a wos:Category ;\n" +
                 "       rdfs:label ?name .\n" +
+                getYearFilter(startYear, endYear) +
                 "}\n" +
                 "ORDER BY DESC(?number)";
         ParameterizedSparqlString q2 = this.storeUtils.getQuery(rq);

--- a/custom-vivo/webapp/src/main/webapp/templates/freemarker/body/individual/individual--wos-unified-organization.ftl
+++ b/custom-vivo/webapp/src/main/webapp/templates/freemarker/body/individual/individual--wos-unified-organization.ftl
@@ -125,7 +125,7 @@ function collabSummary(response, startYear, endYear) {
     if (response.org_totals != []) {
         for(var i in response.org_totals) {
 	    if(response.org_totals[i].year >= startYear) {
-	        yearRange.push(response.org_totals[i].year) 
+	        yearRange.push(response.org_totals[i].year)
 	    }
 	};
         yearRange.sort()
@@ -241,16 +241,18 @@ function doPubCategoryTable(totals, startYear, endYear) {
       </tr>
     `;
     $.each( totals.slice(0, 20), function( key, value ) {
-	var href = base + "/copubs-by-category/" + value.category.split("/")[4] + "?collab=" + individualLocalName;
-	if(startYear > 0) {
-            href += "&startYear=" + startYear;
-	}
-	if(endYear > 0) {
-            href += "&endYear=" + endYear;
-	}
-        var coPubLink = "<a href=\"" + href + "\" target=\"_blank\">" +  value.number + "</a>";
-        var row = "<tr class=\"rep-row\" id=\"cc-" + idkey(value.name) + "\"><td class=\"rep-label\">" + value.name + "</td><td class=\"rep-num\">" + coPubLink + "</td></tr>";
-        html += row;
+        if (value.category != null) {
+        	var href = base + "/copubs-by-category/" + value.category.split("/")[4] + "?collab=" + individualLocalName;
+        	if(startYear > 0) {
+                    href += "&startYear=" + startYear;
+        	}
+        	if(endYear > 0) {
+                    href += "&endYear=" + endYear;
+        	}
+            var coPubLink = "<a href=\"" + href + "\" target=\"_blank\">" +  value.number + "</a>";
+            var row = "<tr class=\"rep-row\" id=\"cc-" + idkey(value.name) + "\"><td class=\"rep-label\">" + value.name + "</td><td class=\"rep-num\">" + coPubLink + "</td></tr>";
+            html += row;
+        }
     });
     html += "</table>";
     return html;

--- a/custom-vivo/webapp/src/main/webapp/templates/freemarker/body/individual/individual--wos-unified-organization.ftl
+++ b/custom-vivo/webapp/src/main/webapp/templates/freemarker/body/individual/individual--wos-unified-organization.ftl
@@ -14,10 +14,12 @@
 <#include "individual.ftl">
 
 <script>
+var individualUri = "${individual.uri}";
 //co-publication report
 $("span.display-title").html('');
 var uni = $("h1.fn").text();
 $("h1.fn").html("DTU collaboration with " + uni.trim() +
+                "<span id=\"collab-summary-country\" class=\"hidden\"></span>" +
                 " from " + "<select id=\"startYear\" name=\"startYear\"></select>" +
                 " to " + "<select id=\"endYear\" name=\"endYear\"></select>");
 if (individualLocalName != "org-technical-university-of-denmark") {
@@ -28,13 +30,15 @@ if (individualLocalName != "org-technical-university-of-denmark") {
     var byDeptUrl = base + '/vds/report/org/' + individualLocalName + "/by-dept";
     info_message_setup();
     info_message("Loading Co-publication report");
+    var searchLink = base + "/search?classgroup=http%3A%2F%2Fvivoweb.org%2Fontology%23vitroClassGrouppublications&querytext=&facet_organization-enhanced_ss=" + encodeURIComponent(individualUri);
     var html = `
         <h2 id="collab-summary">
             <span id="collab-summary-total"></span> co-publications
             <span id="collab-summary-cat"></span>
             <a class="report-export" href="#">Export</a>
         </h2>
-    `;
+        <p><a href="--link--">Show list</a> of all publications since 2007</p>
+    `.replace('--link--', searchLink);
     $("#startYear").corner();
     $("#endYear").corner();
     $("#individual-info").append(html);
@@ -184,6 +188,9 @@ function doSummaryTable(response) {
     <h2>Overview</h2>
     <table id="rep1" class="pub-counts">
     `;
+    if (response.summary.country) {
+        $("#collab-summary-country").html(",&nbsp" + response.summary.country).removeClass("hidden");
+    }
     var orgTotal = response.summary.orgTotal;
     //for(var i in response.org_totals) { orgTotal += response.org_totals[i].count; };
     var orgTotalCites = response.summary.orgCitesTotal;


### PR DESCRIPTION
This does the following. This should be deployed only after the new category data has been loaded which breaks down the collaborators categories by year. 

Changes data to service to:
 - allow year filtering of collaborators categories
 - retrieve country along with organization summary

Changes to co-pub report interface:
- adds link to search results to allow users to list all publications
- adds country name
- minor formatting changes